### PR TITLE
supports new url rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REPODIR=/tmp/tf-repo/providers
 
 NAME=shoreline
 BINARY=terraform-provider-$(NAME)
-VERSION=1.7.7
+VERSION=1.7.8
 
 // NOTE: this only works for 64 bit linux and MacOs ("darwin")
 OS=$(shell uname | tr 'A-Z' 'a-z')

--- a/provider/opts.go
+++ b/provider/opts.go
@@ -31,7 +31,7 @@ type CliOpts struct {
 	Token       string
 }
 
-const CanonicalUrl = "https://<customer>.<region>.api.shoreline-<cluster>.io"
+const CanonicalUrl = "https://(<backend_node>.)?<customer>.<region>.api.shoreline-<cluster>.io"
 
 var AuthUrl string
 var AuthToken string

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -20,8 +20,8 @@ import (
 )
 
 func CanonicalizeUrl(url string) (urlOut string, err error) {
-	urlRegexStr := "^(http(s)?://)?(?P<customer>[^\\.]*).(?P<region>[^\\.]*).ap[ip].shoreline-(?P<cluster>[^\\.]*).io(/)?$"
-	urlBaseStr := "https://${customer}.${region}.api.shoreline-${cluster}.io"
+	urlRegexStr := `^(http(s)?://)?(?P<backend_node>([^\\.]*)\.)?(?P<customer>[^\\.]*)\.(?P<region>[^\\.]*)\.ap[ip]\.shoreline-(?P<cluster>[^\\.]*)\.io(/)?$`
+	urlBaseStr := "https://${backend_node}${customer}.${region}.api.shoreline-${cluster}.io"
 	urlRegex := regexp.MustCompile(urlRegexStr)
 	match := urlRegex.FindStringSubmatch(url)
 	if len(match) < 4 {

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -571,3 +571,52 @@ func getAccResourceNotebook(prefix string) string {
 		}
 `
 }
+
+func TestCanonicalizeUrl(t *testing.T) {
+	testCases := []struct {
+		inputUrl  string
+		expected  string
+		shouldErr bool
+	}{
+		{
+			inputUrl:  "test.us.app.shoreline-dev.io/",
+			expected:  "https://test.us.api.shoreline-dev.io",
+			shouldErr: false,
+		},
+		{
+			inputUrl:  "http://test.us.app.shoreline-dev.io",
+			expected:  "https://test.us.api.shoreline-dev.io",
+			shouldErr: false,
+		},
+		{
+			inputUrl:  "http://proxy.test.us.app.shoreline-dev.io",
+			expected:  "https://proxy.test.us.api.shoreline-dev.io",
+			shouldErr: false,
+		},
+		{
+			inputUrl:  "node0.test.us.api.shoreline-dev.io",
+			expected:  "https://node0.test.us.api.shoreline-dev.io",
+			shouldErr: false,
+		},
+		{
+			inputUrl:  "us.api.shoreline-dev.io",
+			expected:  "",
+			shouldErr: true,
+		},
+		{
+			inputUrl:  "test.us.api.shoreline.io",
+			expected:  "",
+			shouldErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		output, err := CanonicalizeUrl(testCase.inputUrl)
+		if err != nil && !testCase.shouldErr {
+			t.Fatalf("test case failed %s, err: %v\n", testCase.inputUrl, err)
+		}
+		if output != testCase.expected && !testCase.shouldErr {
+			t.Fatalf("test case %s output: %s is not expected: %s\n", testCase.inputUrl, output, testCase.expected)
+		}
+	}
+}


### PR DESCRIPTION
new url format:
`"https://(<backend_node>.)?<customer>.<region>.api.shoreline-<cluster>.io"`