### PR TITLE
fix for ci notary

### DIFF
--- a/.github/workflows/ci-sign-notarize-mac-cli.yaml
+++ b/.github/workflows/ci-sign-notarize-mac-cli.yaml
@@ -35,23 +35,25 @@ jobs:
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
           version: ${{ github.event.inputs.version }}
         run: |
+          mkdir amd64
           chmod 755 ./terraform-provider-shoreline_${version}_darwin_amd64
-          mv ./terraform-provider-shoreline_${version}_darwin_amd64 ./terraform-provider-shoreline_${version}_darwin_amd64.command
-          chmod 755 ./terraform-provider-shoreline_${version}_darwin_amd64.command
-          codesign -s "E4C09D7E61638C54FFD01886C778C5474B9F958D" -f -v --timestamp --options runtime ./terraform-provider-shoreline_${version}_darwin_amd64.command
+          mv ./terraform-provider-shoreline_${version}_darwin_amd64 ./amd64/terraform-provider-shoreline_${version}_darwin_amd64.command
+          chmod 755 ./amd64/terraform-provider-shoreline_${version}_darwin_amd64.command
+          codesign -s "E4C09D7E61638C54FFD01886C778C5474B9F958D" -f -v --timestamp --options runtime ./amd64/terraform-provider-shoreline_${version}_darwin_amd64.command
           xcrun notarytool store-credentials "notary_credentials" --apple-id "build@shorelinesoftware.com" --team-id "8BF8P3HDAA" --password "${{ secrets.AC_PASSWORD }}"
-          create-dmg --notarize "notary_credentials" terraform-provider-shoreline_${version}_darwin_amd64.dmg ./
+          create-dmg --notarize "notary_credentials" terraform-provider-shoreline_${version}_darwin_amd64.dmg ./amd64/
       - name: Sign and notarize mac M1 cli
         env:
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
           version: ${{ github.event.inputs.version }}
         run: |
+          mkdir arm64
           chmod 755 ./terraform-provider-shoreline_${version}_darwin_arm64
-          mv ./terraform-provider-shoreline_${version}_darwin_arm64 ./terraform-provider-shoreline_${version}_darwin_arm64.command
-          chmod 755 ./terraform-provider-shoreline_${version}_darwin_arm64.command
-          codesign -s "E4C09D7E61638C54FFD01886C778C5474B9F958D" -f -v --timestamp --options runtime ./terraform-provider-shoreline_${version}_darwin_arm64.command
+          mv ./terraform-provider-shoreline_${version}_darwin_arm64 ./arm64/terraform-provider-shoreline_${version}_darwin_arm64.command
+          chmod 755 ./arm64/terraform-provider-shoreline_${version}_darwin_arm64.command
+          codesign -s "E4C09D7E61638C54FFD01886C778C5474B9F958D" -f -v --timestamp --options runtime ./arm64/terraform-provider-shoreline_${version}_darwin_arm64.command
           xcrun notarytool store-credentials "notary_credentials" --apple-id "build@shorelinesoftware.com" --team-id "8BF8P3HDAA" --password "${{ secrets.AC_PASSWORD }}"
-          create-dmg --notarize "notary_credentials" terraform-provider-shoreline_${version}_darwin_arm64.dmg ./
+          create-dmg --notarize "notary_credentials" terraform-provider-shoreline_${version}_darwin_arm64.dmg ./arm64/
       - name: Upload signed cli to S3
         env:
           version: ${{ github.event.inputs.version }}


### PR DESCRIPTION
moving the amd and arm cli to their respective directories before create-dmg