### PR TITLE
Fix runbook inline bugs

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -915,7 +915,7 @@ func resourceShorelineObject(configJsStr string, key string) *schema.Resource {
 					return true
 				}
 
-				if k == "params" {
+				if k == "params" || k == "external_params" {
 					oldJs, oldErr := StringToJsonArray(old)
 					nuJs, nuErr := StringToJsonArray(nu)
 					//appendActionLog(fmt.Sprintf("notebook.params DiffSuppressFunc(), PRE  old: %+v \n", oldJs))
@@ -923,8 +923,13 @@ func resourceShorelineObject(configJsStr string, key string) *schema.Resource {
 					if oldErr != nil || nuErr != nil {
 						return false
 					}
-					AddNotebookParamsFields(nuJs)
-					AddNotebookParamsFields(oldJs)
+					if k == "params" {
+						AddNotebookParamsFields(nuJs)
+						AddNotebookParamsFields(oldJs)
+					} else {
+						AddNotebookExternalParamsFields(nuJs)
+						AddNotebookExternalParamsFields(oldJs)
+					}
 					//appendActionLog(fmt.Sprintf("notebook.params DiffSuppressFunc(), POST old: %+v \n", oldJs))
 					//appendActionLog(fmt.Sprintf("notebook.params DiffSuppressFunc(), POST nu: %+v \n", nuJs))
 					if reflect.DeepEqual(oldJs, nuJs) {
@@ -1003,9 +1008,9 @@ func AddNotebookExternalParamsFields(externalParams []interface{}) {
 	for _, v := range externalParams {
 		theMap, isMap := v.(map[string]interface{})
 		if isMap {
-			_, hasExport := theMap["export"]
-			if !hasExport {
-				theMap["export"] = false
+			_, hasValue := theMap["value"]
+			if !hasValue {
+				theMap["value"] = ""
 			}
 		}
 	}

--- a/provider/provider_conf.go
+++ b/provider/provider_conf.go
@@ -231,7 +231,7 @@ var ObjectConfigJsonStr = `
 			"#enabled":                 { "type": "bool",       "optional": true, "step": "enabled", "default": true, "conflicts": ["data"]},
 			"cells":                   { "type": "b64json",    "optional": true, "step": "skip.param", "outtype": "json", "conflicts": ["data"]},
 			"params":                  { "type": "b64json",    "optional": true, "outtype": "json", "conflicts": ["data"], "match_null": "[]"},
-			"external_params":         { "type": "b64json",    "optional": true, "outtype": "json", "conflicts": ["data"]},
+			"external_params":         { "type": "b64json",    "optional": true, "outtype": "json", "conflicts": ["data"], "match_null": "[]"},
 			"enabled":                 { "type": "bool",       "optional": true, "default": true, "conflicts": ["data"]},
 			"description":             { "type": "string",     "optional": true },
 			"timeout_ms":              { "type": "unsigned",   "optional": true, "default": 60000 },

--- a/provider/provider_conf.go
+++ b/provider/provider_conf.go
@@ -222,7 +222,7 @@ var ObjectConfigJsonStr = `
 																	 "force_set":  [ "allowed_entities", "approvers", "is_run_output_persisted",
 																	                 "communication_workspace", "communication_channel" ],
 																	 "skip_diff":  [ "allowedUsers", "isRunOutputPersisted", "approvers", "communication",
-																	                 "interactve_state", "name", "allowedResourcesQuery", "timeoutMs" ],
+																	                 "interactive_state", "name", "allowedResourcesQuery", "timeoutMs" ],
 																	 "outtype": "json"
 			                           },
 			"#cells":                   { "type": "b64json",    "optional": true, "step": "cells", "outtype": "json", "conflicts": ["data"]},

--- a/provider/runbook_utils.go
+++ b/provider/runbook_utils.go
@@ -162,11 +162,16 @@ func buildExternalParametersData(d *schema.ResourceData) ([]interface{}, error) 
 		if !exists {
 			value = ""
 		}
+		jsonPath, exists := externalParameter.(map[string]interface{})["json_path"]
+		if !exists {
+			jsonPath = ""
+		}
 
 		externalParameterData := map[string]interface{}{
-			"name":   name,
-			"source": source,
-			"value":  value,
+			"name":      name,
+			"source":    source,
+			"value":     value,
+			"json_path": jsonPath,
 		}
 
 		externalParametersData = append(externalParametersData, externalParameterData)


### PR DESCRIPTION
### Fixes
- [x] Fix `external_params` appearing in the `terraform apply/plan` diff if they were set to empty list and the remote also had an empty list
- [x] Fix `external_params` failing to be applied due to missing `json_path`
- [x] Fix `external_params` appearing to have the values changed when the value was an empty string (normalize external params)

The above require https://github.com/shorelinesoftware/shoreline/pull/13445 running on the backend.