### PR TITLE
[SHORA-2151] Restrict allowed keys in shoreline_notebook.data json

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -1054,9 +1055,20 @@ func resourceShorelineObject(configJsStr string, key string) *schema.Resource {
 		DeleteContext: resourceShorelineObjectDelete(key, objectDef),
 		Importer:      &schema.ResourceImporter{State: schema.ImportStatePassthrough},
 
-		Schema: params,
+		Schema:        params,
+		CustomizeDiff: buildCustomizeDiffFunc(key),
 	}
 
+}
+
+func buildCustomizeDiffFunc(objectType string) schema.CustomizeDiffFunc {
+	if !(objectType == "notebook" || objectType == "runbook") {
+		return nil
+	}
+	runbookCustomizeDiff := customdiff.ValidateChange("data", func(ctx context.Context, old, new, meta interface{}) error {
+		return validateShorelineNotebookDataField(new)
+	})
+	return runbookCustomizeDiff
 }
 
 func AddNotebookParamsFields(params []interface{}) {
@@ -1810,12 +1822,6 @@ func resourceShorelineObjectSetFields(typ string, attrs map[string]interface{}, 
 			key = "data"
 			val, exists := d.GetOk(key)
 			// NOTE: Terraform reports !exists when a value is explicitly supplied, but matches the 'default'
-			if exists {
-				validationErr := validateShorelineNotebookDataField(val)
-				if validationErr != nil {
-					return diag.Errorf(validationErr.Error())
-				}
-			}
 			if exists || d.HasChange(key) {
 				runbookData = val
 			}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1810,6 +1810,12 @@ func resourceShorelineObjectSetFields(typ string, attrs map[string]interface{}, 
 			key = "data"
 			val, exists := d.GetOk(key)
 			// NOTE: Terraform reports !exists when a value is explicitly supplied, but matches the 'default'
+			if exists {
+				validationErr := validateShorelineNotebookDataField(val)
+				if validationErr != nil {
+					return diag.Errorf(validationErr.Error())
+				}
+			}
 			if exists || d.HasChange(key) {
 				runbookData = val
 			}

--- a/provider/validation.go
+++ b/provider/validation.go
@@ -1,0 +1,13 @@
+package provider
+
+import "errors"
+
+func validateShorelineNotebookDataField(data interface{}) error {
+	allowedKeys := map[string]bool{"cells": true, "params": true, "external_params": true, "enabled": true}
+	for k := range CastToObject(data).(map[string]interface{}) {
+		if ok := allowedKeys[k]; !ok {
+			return errors.New("shoreline_notebook.data field is expected to only have the following keys: cells, params, external_params and enabled, but got: " + k)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
One issue that occurred recently is that one of our colleagues place the whole runbook config in the sideloaded `data` json file. This causes the provider to display a ton of diffs, mainly for each extra field from the json file.

Output the following error if the json data file is not in the expected for:
```
╷
│ Error: shoreline_notebook.data field is only expected to have the following keys: cells, params, external_params, enabled
│
│   with shoreline_notebook.SRT3,
│   on main.tf line 85, in resource "shoreline_notebook" "SRT3":
│   85: resource "shoreline_notebook" "SRT3" {
│
╵
```