### PR TITLE
[SHORA-2187] Fix validation when data field is not specified

### DIFF
--- a/provider/validation.go
+++ b/provider/validation.go
@@ -3,8 +3,12 @@ package provider
 import "errors"
 
 func validateShorelineNotebookDataField(data interface{}) error {
+	dataObject := CastToObject(data)
+	if dataObject == nil {
+		return nil
+	}
 	allowedKeys := map[string]bool{"cells": true, "params": true, "external_params": true, "enabled": true}
-	for k := range CastToObject(data).(map[string]interface{}) {
+	for k := range dataObject.(map[string]interface{}) {
 		if ok := allowedKeys[k]; !ok {
 			return errors.New("shoreline_notebook.data field is expected to only have the following keys: cells, params, external_params and enabled, but got: " + k)
 		}


### PR DESCRIPTION
FIx validation crashing. If inline `cells` are used instead of the `data` field, then the `data` field will be a `nil` object, so account for that as well.