### PR TITLE
Change validation to warning instead of breaking change

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -693,6 +692,7 @@ func resourceShorelineObject(configJsStr string, key string) *schema.Resource {
 		}
 
 		sch := &schema.Schema{}
+		maybeAddValidateFunc(sch, key, k)
 
 		description := CastToString(GetNestedValueOrDefault(objects, ToKeyPath("docs.attributes."+k), ""))
 		sch.Description = description
@@ -1066,20 +1066,9 @@ func resourceShorelineObject(configJsStr string, key string) *schema.Resource {
 		DeleteContext: resourceShorelineObjectDelete(key, objectDef),
 		Importer:      &schema.ResourceImporter{State: schema.ImportStatePassthrough},
 
-		Schema:        params,
-		CustomizeDiff: buildCustomizeDiffFunc(key),
+		Schema: params,
 	}
 
-}
-
-func buildCustomizeDiffFunc(objectType string) schema.CustomizeDiffFunc {
-	if !(objectType == "notebook" || objectType == "runbook") {
-		return nil
-	}
-	runbookCustomizeDiff := customdiff.ValidateChange("data", func(ctx context.Context, old, new, meta interface{}) error {
-		return validateShorelineNotebookDataField(new)
-	})
-	return runbookCustomizeDiff
 }
 
 func AddNotebookParamsFields(params []interface{}) {

--- a/provider/validation.go
+++ b/provider/validation.go
@@ -24,7 +24,7 @@ func maybeAddValidateFunc(sch *schema.Schema, shorelineObjectType, fieldName str
 func getExtraShorelineNotebookDataFields(data interface{}) []string {
 	dataObject := CastToObject(data)
 	if dataObject == nil {
-		return nil
+		return []string{}
 	}
 	allowedKeys := map[string]bool{"cells": true, "params": true, "external_params": true, "enabled": true}
 	extraKeys := []string{}

--- a/provider/validation.go
+++ b/provider/validation.go
@@ -1,17 +1,37 @@
 package provider
 
-import "errors"
+import (
+	"fmt"
 
-func validateShorelineNotebookDataField(data interface{}) error {
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func maybeAddValidateFunc(sch *schema.Schema, shorelineObjectType, fieldName string) {
+	if fieldName == "data" && (shorelineObjectType == "notebook" || shorelineObjectType == "runbook") {
+		sch.ValidateFunc = func(val interface{}, key string) (warns []string, errs []error) {
+			if key != "data" {
+				return
+			}
+			extraKeys := getExtraShorelineNotebookDataFields(val)
+			if len(extraKeys) > 0 {
+				warns = append(warns, fmt.Sprintf("shoreline_notebook.data field is expected to only have the following keys: cells, params, external_params and enabled, but got extra keys: %v. This may produce unwanted diffs.", extraKeys))
+			}
+			return
+		}
+	}
+}
+
+func getExtraShorelineNotebookDataFields(data interface{}) []string {
 	dataObject := CastToObject(data)
 	if dataObject == nil {
 		return nil
 	}
 	allowedKeys := map[string]bool{"cells": true, "params": true, "external_params": true, "enabled": true}
+	extraKeys := []string{}
 	for k := range dataObject.(map[string]interface{}) {
 		if ok := allowedKeys[k]; !ok {
-			return errors.New("shoreline_notebook.data field is expected to only have the following keys: cells, params, external_params and enabled, but got: " + k)
+			extraKeys = append(extraKeys, k)
 		}
 	}
-	return nil
+	return extraKeys
 }


### PR DESCRIPTION
If the sideloaded data json file contains extra fields, the plan/apply will print this warning:

```
Plan: 2 to add, 0 to change, 0 to destroy.
╷
│ Warning: shoreline_notebook.data field is expected to only have the following keys: cells, params, external_params and enabled, but got extra keys: [lorem]
│
│   with shoreline_notebook.SRT3,
│   on main.tf line 94, in resource "shoreline_notebook" "SRT3":
│   94:   data                                  = file("runbooks/srt3/SRT3.json")
│
│ (and one more similar warning elsewhere)
╵
```

This will still allow the creation and update of runbooks and no longer produces an error