### PR TITLE
[SHORA-2255] Upload file to S3 / Azure – let golang http library handle content length

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REPODIR=/tmp/tf-repo/providers
 
 NAME=shoreline
 BINARY=terraform-provider-$(NAME)
-VERSION=1.15.26
+VERSION=1.15.28
 
 // NOTE: this only works for 64 bit linux and MacOs ("darwin")
 OS=$(shell uname | tr 'A-Z' 'a-z')

--- a/README.md
+++ b/README.md
@@ -77,3 +77,13 @@ To do that, simply uncomment this line in `devcontainer.json`:
     // "runArgs": ["--network=shoreline-net"],
 ```
 and then rebuild the container, making sure the podman network was created by the shoreline-in-a-box run script.
+
+
+### Troubleshooting / FAQ
+
+###### `cp` / creating `shoreline_file`s via terraform does not work
+Check backend container for error logs.
+
+Ensure you've set the `ENABLE_LOCAL_OP_COPY` flag (see above for more information).
+
+Also, ensure that the AWS credentials are set on the ceph containers and on the backend (`aws sso login` then `podman login` with the default AWS credentials). Credentials expire after some time (~12 hours) which may cause op copy to stop working all of a sudden. This is because the backend will fail to presign the PUT url if the AWS credentials are invalid / expired / not set.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ and then rebuild the container, making sure the podman network was created by th
 
 ### Troubleshooting / FAQ
 
-###### `cp` / creating `shoreline_file`s via terraform does not work
+###### Creating `shoreline_file`s via terraform does not work
 Check backend container for error logs.
 
 Ensure you've set the `ENABLE_LOCAL_OP_COPY` flag (see above for more information).

--- a/provider/opts.go
+++ b/provider/opts.go
@@ -348,7 +348,7 @@ func UploadFileHttps(src string, dst string, token string) error {
 		return fmt.Errorf("couldn't create upload request object: %s", err.Error())
 	}
 	reqOb.Header.Set("x-ms-blob-type", "BlockBlob") // only used by Azure, ignored by S3
-	reqOb.Header.Set("Content-Length", fmt.Sprintf("%d", fileSize))
+	reqOb.ContentLength = fileSize
 
 	response, err := http.DefaultClient.Do(reqOb)
 	if err != nil {


### PR DESCRIPTION
According to documentation, the Go http library expects the `Content-Length` to be managed internally when sending the request, and directly setting it can cause a mismatch between the actual body length and the header value, leading to errors from servers like S3.

Specifically in this case, we were getting `status: 501 Not Implemented` when using the presigned url from the backend to upload a file to S3.

This PR reverts a change which was setting the `Content-Length` header manually.