### PR TITLE
SHORA-2248 TF provider crashes when trying to create a notebook with `allowed_resources_query`

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1010,7 +1010,7 @@ func resourceShorelineObject(configJsStr string, key string) *schema.Resource {
 						return true
 					}
 				default:
-					if nu == defowlt.(string) && (preferredSettingNewValue.(string) != defowlt.(string)) {
+					if defowlt != nil && nu == defowlt.(string) && (preferredSettingNewValue.(string) != defowlt.(string)) {
 						return true
 					}
 				}
@@ -1036,7 +1036,7 @@ func resourceShorelineObject(configJsStr string, key string) *schema.Resource {
 						return true
 					}
 				default:
-					if nu == defowlt.(string) && deprecatedSettingNewValue.(string) != defowlt.(string) {
+					if defowlt != nil && nu == defowlt.(string) && deprecatedSettingNewValue.(string) != defowlt.(string) {
 						return true
 					}
 				}


### PR DESCRIPTION
`defowlt` is not set for `data` and `allowed_resources_query`. This causes the provider to crash because it tries to cast a `nil` to `string` with `defowlt.(string)` .