### PR TITLE
Allow 'name' of a runbook cell to be set

### DIFF
--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -820,8 +820,8 @@ func buildMockAccResourceReportTemplate(prefix string, full bool) string {
 			  depends_on = [
 					shoreline_report_template.` + report_name + `
 				]
-			}	
-			
+			}
+
 			resource "shoreline_report_template" "linked_report_template" {
 				name = "linked_report_template"
 				blocks = ` + wrapJsonEncode("[]") + `
@@ -979,11 +979,11 @@ func TestAccResourceRunbook(t *testing.T) {
 }
 
 func buildMockRunbookCells() string {
-	return "[{\"md\":\"CREATE\"},{\"op\":\"action success = `echo SUCCESS`\"},{\"op\":\"enable success\"},{\"op\":\"success\",\"enabled\":false},{\"md\":\"CLEANUP\"},{\"op\":\"delete success\"}]"
+	return "[{\"md\":\"CREATE\"},{\"op\":\"action success = `echo SUCCESS`\", \"name\":\"success\"},{\"op\":\"enable success\"},{\"op\":\"success\",\"enabled\":false},{\"md\":\"CLEANUP\"},{\"op\":\"delete success\"}]"
 }
 
 func buildExpectedRunbookCells() string {
-	return "[\n  {\n    \"enabled\": true,\n    \"md\": \"CREATE\",\n    \"name\": \"unnamed\"\n  },\n  {\n    \"enabled\": true,\n    \"name\": \"unnamed\",\n    \"op\": \"action success = `echo SUCCESS`\"\n  },\n  {\n    \"enabled\": true,\n    \"name\": \"unnamed\",\n    \"op\": \"enable success\"\n  },\n  {\n    \"enabled\": false,\n    \"name\": \"unnamed\",\n    \"op\": \"success\"\n  },\n  {\n    \"enabled\": true,\n    \"md\": \"CLEANUP\",\n    \"name\": \"unnamed\"\n  },\n  {\n    \"enabled\": true,\n    \"name\": \"unnamed\",\n    \"op\": \"delete success\"\n  }\n]"
+	return "[\n  {\n    \"enabled\": true,\n    \"md\": \"CREATE\",\n    \"name\": \"unnamed\"\n  },\n  {\n    \"enabled\": true,\n    \"name\": \"success\",\n    \"op\": \"action success = `echo SUCCESS`\"\n  },\n  {\n    \"enabled\": true,\n    \"name\": \"unnamed\",\n    \"op\": \"enable success\"\n  },\n  {\n    \"enabled\": false,\n    \"name\": \"unnamed\",\n    \"op\": \"success\"\n  },\n  {\n    \"enabled\": true,\n    \"md\": \"CLEANUP\",\n    \"name\": \"unnamed\"\n  },\n  {\n    \"enabled\": true,\n    \"name\": \"unnamed\",\n    \"op\": \"delete success\"\n  }\n]"
 }
 
 func buildMockRunbookParams() string {

--- a/provider/runbook_utils.go
+++ b/provider/runbook_utils.go
@@ -74,6 +74,11 @@ func buildCellsData(cells interface{}) (interface{}, error) {
 			return nil, fmt.Errorf(`runbook cell 'enabled' must be a boolean (or not set).`)
 		}
 
+		name, enOk := GetNestedValueOrDefault(cell, ToKeyPath("name"), "unnamed").(string)
+		if !enOk {
+			return nil, fmt.Errorf(`runbook cell 'name' must be a string (or not set).`)
+		}
+
 		secretAware, enOk := GetNestedValueOrDefault(cell, ToKeyPath("secret_aware"), false).(bool)
 		if !enOk {
 			return nil, fmt.Errorf(`runbook cell 'secret_aware' must be a boolean (or not set).`)
@@ -87,7 +92,7 @@ func buildCellsData(cells interface{}) (interface{}, error) {
 				"content":      markdownContent,
 				"enabled":      enabled,
 				"type":         "MARKDOWN",
-				"name":         "unnamed",
+				"name":         name,
 				"secret_aware": secretAware,
 			}
 		} else {
@@ -98,7 +103,7 @@ func buildCellsData(cells interface{}) (interface{}, error) {
 				"content":      oplangContent,
 				"enabled":      enabled,
 				"type":         "OP_LANG",
-				"name":         "unnamed",
+				"name":         name,
 				"secret_aware": secretAware,
 			}
 		}


### PR DESCRIPTION
In an older version of the provider before the transition from `data` --> `cells` + `params`, we use this field to be able to pass metadata to our CI pipeline. We're currently blocked from updating to the latest provider because of the need for this ability. Submitting a patch request to open back up this avenue for us.